### PR TITLE
Add The R flag as readonly for compatibility with Vi and the others clones.

### DIFF
--- a/main.c
+++ b/main.c
@@ -94,9 +94,9 @@ char **argv;
     fillchar(&args, sizeof args, 0);
 
 #if UCSD_COMPAT
-#  define OPTIONS "eprt:"
+#  define OPTIONS "eprRt:"
 #else
-#  define OPTIONS "ert:"
+#  define OPTIONS "erRt:"
 #endif
 
     while ( (opt=getopt(argc, argv, OPTIONS)) != EOF ) {
@@ -107,6 +107,7 @@ char **argv;
 		break;
 #endif
 	    case 'r':	/* readonly */
+	    case 'R':
 		readonly = is_viewer = YES;
 		break;
 	    case 'e':	/* start in exec mode */


### PR DESCRIPTION
Levee uses -r flag for readonly but this flag is used by the other for recovering files. 
Currently Levee doesn't complain if unknown flags are introduced so a user could be using the -R flag without knowing It is not doing anything.
