### PR TITLE
Show a error message when the command is not found

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -1065,7 +1065,7 @@ char *default_cmd;
     for (k=0; excmds[k].name; k++)
 	if (excmds[k].active && strncmp(cmd, excmds[k].name, j) == 0)
 	    return k;
-    return ERR;
+    return EX_UNKNOWN;
 }
 
 


### PR DESCRIPTION
Right know Levee doesn't show an error message when the ex command is unknown.
It know will show the message "Not an editor command."