### PR TITLE
Fix a BUG that causes Levee to exit suddenly in the colon line after pressing escape or delete.

### DIFF
--- a/main.c
+++ b/main.c
@@ -181,7 +181,7 @@ exec_type emode;
 {
     bool more;			/* used [more] at end of line */
     exec_type mode;
-    int exit_now;		/* exec says time to go */
+    int exit_now = 0;		/* exec says time to go */
 
     zotscreen = redraw = FALSE;
 


### PR DESCRIPTION
On i386 machines (tested on Linux and NetBSD) if you go to the colon line and press  escape or delete it will exit without saving the buffer. On  my i64 Linux machine I don't have this problem.

I was just an uninitialized variable