### PR TITLE
Fix a bug that causes to segfault when execute nextfile with different sizes [Only on Linux]

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -877,12 +877,17 @@ bool prev;
 	else {
 	    /* toss the old args; s-l-o-w-l-y copy the new ones in */
 	    os_globfree(&args);
-	    for ( i=0; i < files.gl_pathc; i++ ) {
-		rc = os_glob(files.gl_pathv[i], GLOB_APPEND|GLOB_NOMAGIC, &args);
-		if ( rc ) {
+		rc = os_glob(files.gl_pathv[0], GLOB_NOMAGIC, &args);
+		if ( rc ) 
 		    errmsg(noalloc);
-		    break;
-		}
+		else {
+			for ( i=1; i < files.gl_pathc; i++ ) {
+			rc = os_glob(files.gl_pathv[i], GLOB_APPEND|GLOB_NOMAGIC, &args);
+				if ( rc ) {
+					errmsg(noalloc);
+					break;
+				}
+			}
 	    }
 	    current = 0;
 	}


### PR DESCRIPTION
On i386 if you execute nextfile several times with different number of arguments it will segfault. on i64 you get something like "double free" exception or something like that if you persist for a while.

It only happens on Linux because you can not use the flag GLOB_APPEND on the first call of a glob function. I was going to blame Linux but it is actually a POSIX thing. NetBSD doesn't have this problem and I think the man page doesn't say anything about it.

https://linux.die.net/man/3/glob
https://pubs.opengroup.org/onlinepubs/007908799/xsh/glob.html

